### PR TITLE
sidestep goship checks for now

### DIFF
--- a/parse/load-batch.sh
+++ b/parse/load-batch.sh
@@ -1,5 +1,5 @@
-A=/tmp/aomlSelection.G.txt
-B=/tmp/aomlSelection.H.txt
+A=/tmp/aomlSelection.I.txt
+B=/tmp/aomlSelection.J.txt
 rm ${A}.log ${B}.log
 bash loadDB.sh $A  &
 pids[0]=$!

--- a/parse/roundtrip.py
+++ b/parse/roundtrip.py
@@ -13,6 +13,8 @@ db = client.argo
 while True:
 	time.sleep(60)
 	p = list(db.profiles.aggregate([{"$sample": {"size": 1}}]))[0]
+	while 'expocode' in p:
+		p = list(db.profiles.aggregate([{"$sample": {"size": 1}}]))[0]
 	#p = list(db.profiles.find({"_id":"3900070_076"}))[0]
 
 	p_lookup = {level[p['data_keys'].index('pres')]: ma.masked_array(level, [False]*len(level)) for level in p['data']} # transform argovis profile data into pressure-keyed lookup table of levels with values sorted as data_keys. Levels are initialized as masked arrays with no elements masked.


### PR DESCRIPTION
Of course we want to doublecheck goship profiles asap, but demure for now so we can keep passively checking argo profiles in the interim.