### PR TITLE
allow null for profile timestamps

### DIFF
--- a/roundtrip.py
+++ b/roundtrip.py
@@ -15,7 +15,7 @@ while True:
 	p = list(db.profiles.aggregate([{"$sample": {"size": 1}}]))[0]
 	while 'expocode' in p:
 		p = list(db.profiles.aggregate([{"$sample": {"size": 1}}]))[0]
-	#p = list(db.profiles.find({"_id":"1900438_447"}))[0]
+	#p = list(db.profiles.find({"_id":"3900785_069"}))[0]
 
 	p_lookup = {level[p['data_keys'].index('pres')]: ma.masked_array(level, [False]*len(level)) for level in p['data']} # transform argovis profile data into pressure-keyed lookup table of levels with values sorted as data_keys. Levels are initialized as masked arrays with no elements masked.
 	nc = []

--- a/util/helpers.py
+++ b/util/helpers.py
@@ -253,7 +253,6 @@ def extract_metadata(ncfile, pidx=0):
     ## timestamp: 
     metadata['timestamp'] = xar['JULD'].to_dict()['data'][pidx]
     if metadata['timestamp'] is None:
-        metadata['timestamp'] = datetime.datetime(9999, 1, 1)
         data_warning.append('missing_timestamp')
 
     ## date_updated_argovis


### PR DESCRIPTION
corresponds to https://github.com/argovis/db-schema/pull/12, so the nightly updates from ifremer stop getting coerced into a timesamp fill value.