### PR TITLE
url construction error, dealing with nans in roundtrip

### DIFF
--- a/devpod.yaml
+++ b/devpod.yaml
@@ -15,13 +15,15 @@ spec:
   containers:
   - name: ifremer
     imagePullPolicy: Always
-    image: argovis/ifremer-sync:dev-sec
-    #command: ['sleep', '1000000000000']
-    # command: ['bash', 'testload.sh', '/logs/xaa']
-    # command: ['bash', 'testload.sh', '/logs/xab']
-    # command: ['bash', 'testload.sh', '/logs/xac']
-    # command: ['bash', 'testload.sh', '/logs/xad']
-    # command: ['bash', 'testload.sh', '/logs/xae']
+    image: argovis/ifremer-sync:dev
+    command: ['sleep', '1000000000000']
+    #command: ['bash', 'testload.sh', '/logs', 'xaa']
+    # command: ['bash', 'testload.sh', '/logs', 'xab']
+    # command: ['bash', 'testload.sh', '/logs', 'xac']
+    # command: ['bash', 'testload.sh', '/logs', 'xad']
+    # command: ['bash', 'testload.sh', '/logs', 'xae']
+    # command: ['bash', 'testload.sh', '/logs', 'xaf']
+    #command: ['bash', 'testload.sh', '/logs', 'xag']
     volumeMounts:
       - mountPath: "/ifremer"
         name: ifremer-mirror
@@ -33,5 +35,5 @@ spec:
         cpu: "0m"
       limits:
         memory: 1000Mi
-        cpu: 500m
+        cpu: 475m
   restartPolicy: Never

--- a/roundtrip.py
+++ b/roundtrip.py
@@ -14,12 +14,16 @@ while True:
 
 	# get a random profile, or pick one by ID
 	p = list(db.argo.aggregate([{"$sample": {"size": 1}}]))[0]
-	#p = list(db.argo.find({"_id":"5906028_072"}))[0]
+	#p = list(db.argo.find({"_id":"4900549_182"}))[0]
 	m = list(db.argoMeta.find({"_id":p['metadata'][0]}))[0]
 	logmessage += 'Checking profile id ' + str(p['_id']) + '\n'
 
 	# transform argovis profile data into dictionary of masked arrays with no elements masked.
-	p_lookup = {var: ma.masked_array(p['data'][i], [False]*len(p['data'][i])) for i, var in enumerate(p['data_info'][0])}
+	if len(p['data']) == len(p['data_info'][0]):
+		p_lookup = {var: ma.masked_array(p['data'][i], [False]*len(p['data'][i])) for i, var in enumerate(p['data_info'][0])}
+	else:
+		# some cases where data array is empty, ie if everything was a nan upstream
+		p_lookup = {var: ma.masked_array([],[]) for i, var in enumerate(p['data_info'][0])}
 	nc = []
 
 	# open all upstream netcdf files asociated with the profile; give up on read errors.

--- a/util/helpers.py
+++ b/util/helpers.py
@@ -236,7 +236,7 @@ def extract_metadata(ncfile, pidx=0):
         metadata['source'][0]['source'].append('argo_deep')
 
     ### source.url
-    metadata['source'][0]['url'] = 'ftp://ftp.ifremer.fr/ifremer/argo/dac/' + ncfile[9:]
+    metadata['source'][0]['url'] = 'ftp://ftp.ifremer.fr/ifremer/argo/dac/' + ncfile[14:]
 
     ### source.date_updated
     metadata['source'][0]['date_updated'] = datetime.datetime.strptime(xar['DATE_UPDATE'].to_dict()['data'].decode('UTF-8'),'%Y%m%d%H%M%S')


### PR DESCRIPTION
 - nightlies were creating incorrect source.url based on change in ifremer mirror location
 - roundtrip was failing to understand when data arrays were correctly empty due to everything upstream being nans.