### PR TITLE
maintain complete list of what rsync touched in nightly update logs

### DIFF
--- a/ifremer-sync.sh
+++ b/ifremer-sync.sh
@@ -7,8 +7,8 @@ mkdir -p $logdir
 rsync -avzhi --delete --omit-dir-times --no-perms vdmzrs.ifremer.fr::argo/ /bulk/ifremer > ${logdir}/rsynclog
 
 # extract set of profiles to CRUD
-grep '\/profiles\/.*\.nc' ${logdir}/rsynclog | tr -s ' ' | cut -d ' ' -f 2 | sed 's|^|/bulk/ifremer/|g' > ${logdir}/updatedprofiles # updatedprofiles == list of changed .nc files, one per line
-python process-rsync-result.py ${logdir}/updatedprofiles > ${logdir}/process-rsync.log
+grep '\/profiles\/.*\.nc' ${logdir}/rsynclog | tr -s ' ' | cut -d ' ' -f 2 | sed 's|^|/bulk/ifremer/|g' > ${logdir}/rsyncupdates # rsyncupdates == list of changed .nc files, one per line
+python process-rsync-result.py ${logdir}/rsyncupdates > ${logdir}/process-rsync.log
 sort /tmp/profileUpdates.txt | uniq > /tmp/temp && mv /tmp/temp ${logdir}/updatedprofiles # updatedprofiles grouped one profile per line, ie core and synth files combined on one line per profile
 
 # load profiles, with logging


### PR DESCRIPTION
so something else can pick this up independently as needed.