### PR TITLE
use an actual exit code, and report more on bgc metadata wierdness

### DIFF
--- a/ifremer-cron.yaml
+++ b/ifremer-cron.yaml
@@ -10,6 +10,13 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      podFailurePolicy:
+        rules:
+          - action: FailJob
+            onExitCodes:
+              containerName: ifremer-sync
+              operator: In
+              values: [108]
       template:
         metadata:
           name: ifremer-sync

--- a/ifremer-sync.sh
+++ b/ifremer-sync.sh
@@ -17,9 +17,9 @@ while read i ; do python translateProfile.py $i >> ${logdir}/updatedprofiles.log
 # once loading complete, kick off summary precomputation
 python summary-computation.py
 
-# exit with error code 9999 if something bad happened in the ifremer update
+# exit with error code 108 if something bad happened in the ifremer update
 if grep -qi "ERROR" ${logdir}/updatedprofiles.log ; then
-    exit 9999
+    exit 108
 else
     exit 0
 fi

--- a/util/helpers.py
+++ b/util/helpers.py
@@ -374,9 +374,10 @@ def compare_metadata(metadata):
         for c in comparisons:
             if c in metadata[0] and c in m:
                 if metadata[0][c] != m[c]:
-                    print(metadata[0][c], m[c])
+                    print('inconsistent values:', metadata[0][c], m[c])
                     return False
                 elif (c in metadata[0] and c not in m) or (c not in metadata[0] and c in m):
+                    print('inconsistent presence of key:', c)
                     return False
 
     return True


### PR DESCRIPTION
sadly, bash exit codes cannot have power level over 9000.